### PR TITLE
fix(ci): Use dynamic test discovery to resolve ImportError

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
           python-version: '3.10'
 
       - name: Run tests
-        run: python -m unittest builder-operations-playground/tests/test_logger.py
+        run: python -m unittest discover builder-operations/tests

--- a/engineering_logs/session_notes/SRE_Initiative_Kickoff.md
+++ b/engineering_logs/session_notes/SRE_Initiative_Kickoff.md
@@ -1,0 +1,19 @@
+# Session Handoff Summary: SRE Initiative Kickoff
+
+## 1. Initiative Goal
+The current initiative is "Hardening the Ecosystem." The primary goal is to transition from new feature development to a focus on Site Reliability Engineering (SRE). The objective is to make all systems robust, resilient, and reliable.
+
+## 2. Immediate Task
+The first task is to fix the failing CI/CD pipeline, specifically the `ImportError` occurring in the "test" job of our GitHub Actions workflow.
+
+## 3. Necessary Context & Data
+*   **Problem:** The test suite is failing with a `ModuleNotFoundError: No module named 'builder-operations-playground/tests/test_logger'`.
+*   **Root Cause:** This error is a result of the recent architectural refactoring where the `builder-operations-playground` directory was renamed to `builder-operations`. The CI workflow file (`.github/workflows/ci.yml`) contains a hardcoded path to the old directory structure.
+*   **Relevant PR:** The failure originated in the PR for the architectural refactoring: `feat: Establish Initial AI Ecosystem Architecture`.
+*   **CI Platform:** GitHub Actions.
+*   **Failing Command:** `python -m unittest builder-operations-playground/tests/test_logger.py`
+
+## 4. Agreed-Upon Plan
+The approved plan is to replace the brittle, hardcoded test command with a dynamic test discovery command: `python -m unittest discover builder-operations/tests`. This will not only fix the bug but also harden the pipeline against future changes.
+
+This document serves as the "Context Carry-over" for the next session, as per the newly ratified **Session Handoff Protocol**.


### PR DESCRIPTION
This commit resolves an `ImportError` in the CI pipeline that occurred after the `builder-operations-playground` directory was renamed to `builder-operations`.

The previous implementation used a hardcoded path to a specific test file, which became invalid after the refactor.

This change replaces the brittle, hardcoded command with `python -m unittest discover`. This makes the test runner dynamically find all tests within the `builder-operations/tests` directory, fixing the immediate bug and making the CI pipeline more resilient to future file additions or renames.