### PR TITLE
Fix: Grant write permissions to Briefing Assistant workflow

### DIFF
--- a/.github/workflows/briefing_assistant.yml
+++ b/.github/workflows/briefing_assistant.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   run_briefing_assistant:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
The Briefing Assistant workflow was failing to post comments on pull requests that contained only non-code changes. This was due to the default read-only permissions of the `GITHUB_TOKEN` in certain contexts.

This change explicitly grants `pull-requests: write` permission to the `run_briefing_assistant` job in the `briefing_assistant.yml` workflow file. This follows the principle of least privilege by providing the minimum necessary permissions for the workflow to perform its function.