### PR TITLE
feat: Implement Strategy Engine v0.1 (Foundation)

### DIFF
--- a/gemini-citadel/src/index.ts
+++ b/gemini-citadel/src/index.ts
@@ -1,7 +1,7 @@
 import { DataService } from './services/data.service';
+import { StrategyEngine } from './services/strategy.service';
 import * as dotenv from 'dotenv';
 
-// Load environment variables from .env file
 dotenv.config({ path: '.env' });
 
 const main = async () => {
@@ -10,19 +10,20 @@ const main = async () => {
   const rpcUrl = process.env.RPC_URL;
 
   if (!rpcUrl) {
-    console.error('FATAL: RPC_URL is not defined in the environment variables. Please check your .env file.');
+    console.error('FATAL: RPC_URL is not defined. Please check your .env file.');
     process.exit(1);
   }
 
   try {
     const dataService = new DataService(rpcUrl);
+    const strategyEngine = new StrategyEngine(dataService);
 
-    // Test the connection by fetching the latest block number
-    await dataService.getBlockNumber();
+    // This will become the main application loop
+    await strategyEngine.findOpportunities();
 
-    console.log('--- System Initialized Successfully ---');
+    console.log('--- Main Loop Cycle Complete ---');
   } catch (error) {
-    console.error('An error occurred during system initialization:', error);
+    console.error('An error occurred during the main loop cycle:', error);
     process.exit(1);
   }
 };

--- a/gemini-citadel/src/services/strategy.service.ts
+++ b/gemini-citadel/src/services/strategy.service.ts
@@ -1,0 +1,43 @@
+import { DataService } from './data.service';
+
+/**
+ * @interface ArbitrageOpportunity
+ * @description Defines the structure for a potential arbitrage trade.
+ */
+export interface ArbitrageOpportunity {
+  profit: number;
+  path: any[]; // This will be defined in more detail later
+}
+
+/**
+ * @class StrategyEngine
+ * @description The brain of the operation. Analyzes market data to find
+ * profitable arbitrage opportunities.
+ */
+export class StrategyEngine {
+  private dataService: DataService;
+
+  /**
+   * @constructor
+   * @param {DataService} dataService - An instance of the DataService to get market data.
+   */
+  constructor(dataService: DataService) {
+    this.dataService = dataService;
+    console.log('[StrategyEngine] Initialized.');
+  }
+
+  /**
+   * Analyzes the current market state to find arbitrage opportunities.
+   * @returns {Promise<ArbitrageOpportunity | null>} An opportunity if found, otherwise null.
+   */
+  public async findOpportunities(): Promise<ArbitrageOpportunity | null> {
+    console.log('[StrategyEngine] Analyzing market data for opportunities...');
+
+    // In future versions, this method will contain the complex logic
+    // to compare prices across different pools and DEXs.
+    // For v0.1, we will simply simulate that no opportunity was found.
+
+    console.log('[StrategyEngine] No profitable opportunities found in this cycle.');
+    return null;
+  }
+}


### PR DESCRIPTION
This commit introduces the foundational structure for the StrategyEngine service.

- Creates the `gemini-citadel/src/services/strategy.service.ts` file.
- Defines the `StrategyEngine` class with a constructor that accepts a `DataService` instance.
- Implements a placeholder `findOpportunities` method that will be expanded in future versions.
- Integrates the new `StrategyEngine` into the main application entry point (`src/index.ts`), instantiating it and calling the `findOpportunities` method.

This sets the stage for building the core arbitrage logic that will consume data from the DataService.