### PR TITLE
fix(ci): make briefing assistant comment script robust

### DIFF
--- a/.github/workflows/briefing_assistant.yml
+++ b/.github/workflows/briefing_assistant.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Post Briefing as Comment
         uses: actions/github-script@v6
+        # Use an environment variable to safely pass the report body
+        env:
+          REPORT_BODY: ${{ steps.briefing.outputs.report }}
         if: steps.briefing.outputs.report != ''
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,5 +46,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `${{ steps.briefing.outputs.report }}`
+              body: process.env.REPORT_BODY
             });


### PR DESCRIPTION
The previous implementation injected the pull request body directly into the github-script step. When the PR body contained backticks (for code formatting), it caused a JavaScript SyntaxError because it prematurely closed the template literal in the script.

This change fixes the issue by passing the report content as an environment variable (`REPORT_BODY`) to the script step. The script then safely reads the content from `process.env.REPORT_BODY`, preventing any special characters from breaking the script's syntax.