### PR TITLE
feat(tools): create candidate key generator

### DIFF
--- a/tools/candidate_key_generator.py
+++ b/tools/candidate_key_generator.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import sys
+from entropy_replicator import simulate_entropy_pool
+
+def generate_candidate_key(counter: int) -> str:
+    """
+    Generates a candidate ECDSA private key based on a predictable entropy
+    fingerprint and a brute-force counter.
+    """
+    # 1. Get the predictable, 32-character hex entropy string.
+    entropy_hex_string = simulate_entropy_pool()
+
+    # 2. Convert the hex string to bytes.
+    entropy_bytes = bytes.fromhex(entropy_hex_string)
+
+    # 3. Convert the counter to a 4-byte, little-endian integer.
+    counter_bytes = counter.to_bytes(4, byteorder='little')
+
+    # 4. Concatenate the entropy bytes and counter bytes to form the seed.
+    seed_bytes = entropy_bytes + counter_bytes
+
+    # 5. Generate the private key by taking the SHA-256 hash of the seed.
+    private_key_hash = hashlib.sha256(seed_bytes)
+    private_key_hex = private_key_hash.hexdigest()
+
+    return private_key_hex
+
+def main():
+    """
+    Main entry point for the script. Parses command-line arguments and
+    prints a generated private key.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate a candidate private key for Project 'Landfill Key'."
+    )
+    parser.add_argument(
+        "counter",
+        type=int,
+        help="An integer to be used as a brute-force counter."
+    )
+    args = parser.parse_args()
+
+    try:
+        private_key = generate_candidate_key(args.counter)
+        print(private_key)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces the `candidate_key_generator.py` script, a tool designed to generate candidate ECDSA private keys based on a predictable entropy fingerprint and a brute-force counter.

The script takes an integer counter as a command-line argument and uses it to seed the key generation process. The core logic relies on a forensically-accurate simulation of a Windows 7 entropy pool, provided by the `entropy_replicator.py` script.

This new tool is a critical component of the "Construct the Assembly Line" directive, enabling the mass production of candidate keys for analysis. The `entropy_replicator.py` was also corrected to its original, more comprehensive state after a code review identified a regression.