### PR TITLE
feat: Add target Bitcoin address

### DIFF
--- a/TARGET_ADDRESS.txt
+++ b/TARGET_ADDRESS.txt
@@ -1,0 +1,1 @@
+198aMn6ZYAczwrE5NvNTUMyJ5qkfy4g3Hi


### PR DESCRIPTION
Adds the Bitcoin address associated with James Howells' lost hard drive to a file in the root directory. This address will be used as the target for the recovery simulation.