### PR TITLE
feat(research): Add analysis of Bitcoin v0.1.5 key generation

### DIFF
--- a/research/landfill-key/reports/exploitation_strategy.md
+++ b/research/landfill-key/reports/exploitation_strategy.md
@@ -1,0 +1,49 @@
+# Exploitation Strategy for CVE-2009-BITCOIN-ENTROPY
+
+This document outlines a high-level strategy for exploiting the hypothesized vulnerability in the Bitcoin v0.1.5 client's key generation process. The strategy is designed to leverage the existing parallel key search framework, adapting it to our specific, entropy-focused attack vector.
+
+## Guiding Principles
+
+1.  **Preserve Parallelism:** The search for a specific private key is an embarrassingly parallel problem. The existing `key_search_manager.py` and `key_search_worker.py` architecture is well-suited for this and must be preserved to ensure the search is conducted efficiently.
+2.  **Targeted, Not Brute-Force:** This is not a brute-force attack. The search space is narrowed dramatically by our hypothesis. The goal is to replicate a small, high-probability set of initial entropy states.
+3.  **Adapt, Don't Rewrite:** The existing toolchain will be modified, not replaced. This minimizes development time and reduces the risk of introducing new errors.
+
+## Proposed Modifications to the Toolchain
+
+The core idea is to modify the worker script (`key_search_worker.py`) to generate keys based on a simulated, predictable entropy pool rather than a simple counter. The manager (`key_search_manager.py`) will be responsible for orchestrating the generation of this entropy and distributing the search space.
+
+### 1. `entropy_replicator.py` (New Tool)
+
+A new tool will be created to run *once* on the target Windows 7 VM at the beginning of a search session.
+- **Function:** Executes the Windows API calls identified in the `openssl_0.9.8h_entropy_analysis.md` report (e.g., `CreateToolhelp32Snapshot`).
+- **Output:** A single, large file containing the raw "entropy snapshot" of the system at that moment. This file, `entropy_snapshot.bin`, will serve as the baseline for a search session.
+
+### 2. `key_search_manager.py` (Modification)
+
+The manager will be modified to:
+- **Load Baseline Entropy:** Read the `entropy_snapshot.bin` file into memory.
+- **Define Work Chunks:** Instead of distributing simple integer ranges, the manager will distribute work chunks that consist of:
+    - A range of counters (e.g., 0 to 1,000,000).
+    - The baseline entropy snapshot.
+- **Distribute Work:** Send these complex work chunks to the workers.
+
+### 3. `key_search_worker.py` (Modification)
+
+The worker script will be the most significantly modified component. It will be adapted to:
+- **Receive Work Chunk:** Accept the counter range and baseline entropy from the manager.
+- **Iterate and Perturb:** For each counter in its assigned range, the worker will:
+    1.  Create a *copy* of the baseline entropy.
+    2.  "Perturb" this copy in a deterministic way using the counter. For example, it could XOR the counter into the first few bytes of the entropy buffer, or replace a section of the buffer corresponding to a predictable value (like a timestamp) with a new value derived from the counter.
+- **Generate Candidate Key:** Use this perturbed entropy buffer as the seed for the `cryptography` library to generate a candidate private key. This step replaces the old logic of simply converting the counter to a private key.
+- **Derive and Check:** Derive the Bitcoin address and check it against the target address.
+- **Report Success:** If a match is found, report the successful private key and the counter/perturbation that produced it back to the manager.
+
+## Execution Flow
+
+1.  **Setup:** An operator (or an automated script) starts the target Windows 7 VM from a clean snapshot.
+2.  **Entropy Capture:** The `entropy_replicator.py` script is run on the VM, generating `entropy_snapshot.bin`. This file is transferred back to the machine running the key search manager.
+3.  **Search Initiation:** The `key_search_manager.py` is started. It loads the `entropy_snapshot.bin` and begins distributing work to the pool of `key_search_worker.py` processes.
+4.  **Parallel Search:** The workers execute the search in parallel, each exploring a different set of perturbations on the same baseline entropy.
+5.  **Termination:** The search concludes when the key is found or the defined search space has been exhausted. If the key is not found, the process can be repeated from step 1 to capture a new baseline entropy snapshot.
+
+This strategy provides a clear and efficient path to test our vulnerability hypothesis while retaining the performance benefits of the original parallel processing architecture.

--- a/research/landfill-key/reports/openssl_0.9.8h_entropy_analysis.md
+++ b/research/landfill-key/reports/openssl_0.9.8h_entropy_analysis.md
@@ -1,0 +1,51 @@
+# Analysis of Entropy Sources in OpenSSL 0.9.8h on Windows
+
+This document details the entropy sources used by the `RAND_poll()` function in OpenSSL version 0.9.8h, as implemented in `crypto/rand/rand_win.c`. The analysis focuses on the predictability of these sources within a controlled Windows 7 environment, which is the target for "Operation Landfill Key".
+
+## Summary
+
+The `RAND_poll()` function gathers entropy from a variety of system sources. The quality and predictability of this entropy are highly dependent on the system's state and level of interaction. On a freshly booted, non-interactive system, many of these sources are highly predictable.
+
+The primary function call for entropy collection is `RAND_poll()`. Its sources can be categorized as follows:
+
+### 1. Cryptography API (CryptoAPI)
+
+- **Function:** `CryptGenRandom`
+- **Description:** The code first attempts to use the built-in Windows cryptographic random number generator via `CryptAcquireContextW` and `CryptGenRandom`.
+- **Predictability Assessment:** **Low**. If this call succeeds, it provides cryptographically strong random data, which would likely defeat our attack. However, its success can depend on system configuration and state. The failure of this API call is a critical prerequisite for the success of our vulnerability hypothesis.
+
+### 2. Toolhelp32 Snapshot
+
+- **Function:** `CreateToolhelp32Snapshot` with the `TH32CS_SNAPALL` flag.
+- **Description:** This is the most voluminous source of entropy. It captures the state of nearly all user-space objects running on the system. The data from the following structures is added to the entropy pool:
+    - `HEAPLIST32`: A list of all heaps.
+    - `HEAPENTRY32`: The first 80 entries of each heap.
+    - `PROCESSENTRY32`: A list of all running processes.
+    - `THREADENTRY32`: A list of all threads.
+    - `MODULEENTRY32`: A list of all modules (DLLs) loaded by processes.
+- **Predictability Assessment:** **High**. On a freshly booted, controlled VM with a known set of startup processes, the data returned by these functions will be nearly identical across reboots. Minor variations in process IDs, thread IDs, and memory addresses are expected, but the overall structure and content will be highly constrained and predictable. This is our primary attack surface.
+
+### 3. System and Performance Information
+
+- **Functions:** `GlobalMemoryStatus`, `GetCurrentProcessId`, `QueryPerformanceCounter`, `GetTickCount`.
+- **Description:** These functions gather basic system state information:
+    - `GlobalMemoryStatus`: Overall memory usage.
+    - `GetCurrentProcessId`: The ID of the running process.
+    - `QueryPerformanceCounter` / `GetTickCount`: High-resolution timestamps.
+- **Predictability Assessment:** **High to Medium**. Memory usage and process ID will be very predictable on a clean boot. Timestamps introduce variability, but their lower bits are often the most random, and their overall impact might be limited compared to the large volume of data from the Toolhelp32 snapshot.
+
+### 4. GUI State
+
+- **Functions:** `GetForegroundWindow`, `GetCursorInfo`, `GetQueueStatus`.
+- **Description:** This gathers information about user interaction.
+- **Predictability Assessment:** **High (in our scenario)**. These are only polled if the process is not a service. In our target scenario (a non-interactive, freshly booted system), these values will be constant and provide no meaningful entropy.
+
+### 5. Network Statistics
+
+- **Functions:** `NetStatisticsGet`
+- **Description:** The code attempts to gather statistics for the `LanmanWorkstation` and `LanmanServer` services.
+- **Predictability Assessment:** **High**. On a clean boot, especially on an air-gapped machine as intended for the final exploit, these statistics will be zero or a constant, predictable value.
+
+## Conclusion
+
+The security of OpenSSL 0.9.8h's PRNG on Windows is critically dependent on the success of `CryptGenRandom`. If that call fails, the PRNG is seeded with data that is highly predictable on a controlled system. The **Toolhelp32 snapshot** is the largest and most promising source of predictable data to target for replication.

--- a/research/landfill-key/reports/vulnerability_hypothesis.md
+++ b/research/landfill-key/reports/vulnerability_hypothesis.md
@@ -1,0 +1,33 @@
+# Vulnerability Hypothesis for Bitcoin Client v0.1.5
+
+## 1. Hypothesis Statement
+
+The private key generation process in Bitcoin client v0.1.5 on the Windows 7 operating system is vulnerable to a targeted search attack due to a predictable initial state of its underlying pseudo-random number generator (PRNG). This predictability stems from the client's sole reliance on the OpenSSL v0.9.8h library's `RAND_poll` function for entropy, which, on a non-interactive and freshly booted system, collects data from a limited and deterministic set of system sources.
+
+## 2. Supporting Evidence
+
+This hypothesis is based on the following findings from the source code analysis:
+
+*   **No Application-Layer Seeding:** The Bitcoin client's C++ source code (`main.cpp`, `key.h`, `ui.cpp`) does not perform any explicit, strong seeding of the OpenSSL PRNG before calling `EC_KEY_generate_key()`. The only application-level entropy source is from mouse movements (`RAND_add` in `OnMouseEvents`), which would be minimal or non-existent in our target scenario.
+
+*   **Reliance on Implicit OpenSSL Seeding:** Key generation is therefore dependent on the implicit, automatic seeding performed by OpenSSL's `RAND_poll` function when the PRNG is first used.
+
+*   **Predictable Entropy Sources in `RAND_poll`:** The analysis of OpenSSL 0.9.8h's `rand_win.c` reveals that on a non-interactive Windows system, the primary entropy sources are:
+    1.  **Toolhelp32 Snapshot:** A detailed snapshot of running processes, threads, modules, and heaps. On a controlled, freshly booted VM, the contents of this snapshot are highly deterministic.
+    2.  **System Information:** `GlobalMemoryStatus`, `GetCurrentProcessId`, and timers. These values are also highly predictable on a clean system.
+    3.  **CryptoAPI Failure:** The hypothesis assumes that the call to the strong `CryptGenRandom` function may fail or be unavailable on a base Windows 7 installation, forcing OpenSSL to rely on the weaker, predictable sources. This is a critical point of failure to be tested.
+
+## 3. Attack Vector
+
+The attack vector is as follows:
+
+1.  Provision a controlled Windows 7 VM that replicates the target environment.
+2.  In this VM, execute a tool that gathers the same system state information as `RAND_poll` (the "entropy snapshot").
+3.  Use this captured entropy snapshot as a seed to generate a candidate private key.
+4.  Derive the corresponding Bitcoin address.
+5.  Compare the derived address to the target address (`198aMn6ZYAczwrE5NvNTUMyJ5qkfy4g3Hi`).
+6.  Because the initial system state is not perfectly identical on every boot (e.g., due to process IDs, timestamps), iterate this process, introducing small variations ("perturbations") to the captured entropy to search a narrow, high-probability keyspace around the initial state.
+
+## 4. Conclusion
+
+The confluence of the Bitcoin client's failure to explicitly seed the PRNG and OpenSSL's reliance on predictable system-state information on Windows creates a credible vulnerability. This hypothesis provides a clear, actionable path forward for attempting to recover the private key associated with the target address.


### PR DESCRIPTION
This commit adds a series of documents detailing the analysis of the Bitcoin v0.1.5 client's private key generation process.

The analysis concludes that the client's reliance on OpenSSL 0.9.8h for random number generation, without any application-level seeding, presents a plausible attack vector on a controlled Windows 7 system.

The new documents are:
- `research/landfill-key/reports/openssl_0.9.8h_entropy_analysis.md`: An analysis of the entropy sources used by OpenSSL on Windows.
- `research/landfill-key/reports/vulnerability_hypothesis.md`: A formal statement of the vulnerability hypothesis.
- `research/landfill-key/reports/exploitation_strategy.md`: A high-level strategy for how to adapt the existing toolchain to test the hypothesis.