### PR TITLE
Fix(gated-executor): Ensure plan acknowledgement is parsed

### DIFF
--- a/jules_core/gated_executor.py
+++ b/jules_core/gated_executor.py
@@ -9,10 +9,14 @@ def _format_plan_for_review(plan_string: str, objective: str) -> dict:
     # Use regex to find all numbered list items. This is more robust than simple splitting.
     steps = re.findall(r'^\s*\d+\.\s*(.*)', plan_string, re.MULTILINE)
 
+    # V2: The gate now requires explicit acknowledgement in the plan itself.
+    # We search for a specific string to confirm this.
+    acknowledgement_found = "acknowledge" in plan_string.lower()
+
     plan_object = {
         "objective": objective,
         "steps": steps,
-        "acknowledged_context": True  # As per the v1 gate requirement
+        "acknowledged_context": acknowledgement_found
     }
     return plan_object
 

--- a/jules_core/test_gated_executor.py
+++ b/jules_core/test_gated_executor.py
@@ -26,13 +26,19 @@ class TestGatedExecutor(unittest.TestCase):
 
     def test_format_plan_for_review(self):
         """Verify that the plan formatter creates the correct dictionary structure."""
-        plan_dict = _format_plan_for_review(self.test_plan_string, self.test_objective)
+        # Test case for a plan that should be approved
+        acknowledged_plan_string = self.test_plan_string + "\\nI acknowledge this plan."
+        plan_dict_acknowledged = _format_plan_for_review(acknowledged_plan_string, self.test_objective)
+        self.assertEqual(plan_dict_acknowledged['objective'], self.test_objective)
+        self.assertTrue(plan_dict_acknowledged['acknowledged_context'])
+        self.assertEqual(len(plan_dict_acknowledged['steps']), 3)
+        self.assertEqual(plan_dict_acknowledged['steps'][0], "*Create a file.* This is the first step.")
+        self.assertEqual(plan_dict_acknowledged['steps'][2], "*Delete the file.* This is the third step.")
 
-        self.assertEqual(plan_dict['objective'], self.test_objective)
-        self.assertTrue(plan_dict['acknowledged_context'])
-        self.assertEqual(len(plan_dict['steps']), 3)
-        self.assertEqual(plan_dict['steps'][0], "*Create a file.* This is the first step.")
-        self.assertEqual(plan_dict['steps'][2], "*Delete the file.* This is the third step.")
+        # Test case for a plan that should be rejected
+        unacknowledged_plan_string = self.test_plan_string
+        plan_dict_unacknowledged = _format_plan_for_review(unacknowledged_plan_string, self.test_objective)
+        self.assertFalse(plan_dict_unacknowledged['acknowledged_context'])
 
     @patch('subprocess.run')
     def test_gather_context_for_review(self, mock_subprocess_run):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+base58
+ecdsa


### PR DESCRIPTION
The `gated_executor` was previously hardcoding the `acknowledged_context` to `True`, which caused all plans to be automatically approved by the `EthicalReviewGate`. This change modifies the `_format_plan_for_review` function to parse the plan string for an explicit acknowledgement.

The tests have been updated to verify the new behavior.