### PR TITLE
feat: Add analysis of AxionCitadel architecture

### DIFF
--- a/AXION_CITADEL_ANALYSIS.md
+++ b/AXION_CITADEL_ANALYSIS.md
@@ -1,0 +1,85 @@
+# Analysis of the Axion Citadel Architecture for CEX Integration
+
+## 1. Executive Summary
+
+This document presents a detailed analysis of the `AxionCitadel` repository, a legacy arbitrage trading bot. The purpose of this analysis is to identify and document reusable architectural patterns, code structures, and utilities that can be leveraged for our current project, specifically for the integration of a Centralized Exchange (CEX) like BTCC.
+
+The `AxionCitadel` project, while focused on Decentralized Exchanges (DEXs), exhibits a highly modular, resilient, and extensible architecture. Its design provides a robust blueprint for integrating disparate trading venues (like CEXs) into a unified arbitrage system. By adopting its core architectural patterns, we can significantly accelerate development, improve maintainability, and ensure the scalability of our own trading bot.
+
+The key finding is that `AxionCitadel`'s **Protocol Layer** is a directly applicable and powerful pattern for encapsulating all exchange-specific logic. This allows the core arbitrage engine to remain agnostic to the underlying exchange, treating both DEXs and CEXs as interchangeable modules.
+
+## 2. Key Architectural Patterns for Reuse
+
+The following sections detail the most valuable architectural patterns discovered in `AxionCitadel` and provide a roadmap for their adaptation.
+
+### 2.1. The Protocol Layer: A Blueprint for Exchange Integration
+
+The most critical architectural pattern is the `src/protocols/` directory. This layer is designed to completely isolate the logic required to interact with a specific trading venue.
+
+**Original Implementation (`AxionCitadel`):**
+
+*   Each DEX (e.g., Uniswap, SushiSwap) has its own subdirectory (e.g., `src/protocols/uniswap/`).
+*   Each module contains a `Fetcher` class, responsible for retrieving on-chain data like pool prices and liquidity.
+*   Each module was designed to contain a `TxBuilder` class, responsible for constructing the specific transaction data needed to execute a swap on that DEX.
+
+**Our Adaptation (CEX Integration):**
+
+We will replicate this structure to create a `btcc` protocol module:
+
+*   Create a new directory: `src/protocols/btcc/`.
+*   Inside this directory, we will implement:
+    *   **`BtccFetcher.js`**: This class will be responsible for fetching data from the BTCC API (e.g., order books, ticker prices, account balances). It will conform to a standardized `IFetcher` interface.
+    *   **`BtccOrderBuilder.js`**: This class will replace the `TxBuilder` concept. It will be responsible for constructing and formatting the API requests needed to place, cancel, and query orders on BTCC.
+
+### 2.2. Central Dispatchers: `DataProvider` and `ExecutionManager`
+
+`AxionCitadel` uses central services to manage data and execution, which are fed by the individual protocol modules. This is a powerful pattern for decoupling our core logic from the exchange-specific modules.
+
+**Original Implementation (`AxionCitadel`):**
+
+*   **`DexDataProvider.js`**: A single service that holds a map of all registered `Fetcher` instances. The core application requests data from this provider, which then delegates the call to the appropriate protocol-specific fetcher.
+*   **`TransactionManager.js`**: A service that holds a map of all registered `TxBuilder` instances. It receives a desired trade from the arbitrage engine and uses the correct builder to construct the final transaction.
+
+**Our Adaptation:**
+
+*   We will create an **`ExchangeDataProvider.js`** that will be initialized with both DEX and CEX fetchers (`UniswapV3Fetcher`, `BtccFetcher`, etc.).
+*   We will create an **`ExecutionManager.js`** that can manage both on-chain transactions (via `TxBuilder`s) and off-chain API orders (via our new `OrderBuilder`s).
+
+### 2.3. The Initializer and Protocol Registry: Dynamic Component Assembly
+
+The `AxionCitadel` bot is assembled at runtime by a master `initializer.js` script. This script dynamically discovers and injects the necessary protocol handlers.
+
+**Original Implementation (`AxionCitadel`):**
+
+*   **`src/protocols/index.js`**: This file acts as a **Protocol Registry**. It manually imports all `Fetcher` and `TxBuilder` classes, instantiates them, and provides them to the initializer.
+*   **`src/core/initializer.js`**: This script calls functions in the registry (`getAllFetchers()`, `getAllTxBuilders()`) to get all available protocol handlers. It then injects these handlers into the `DexDataProvider` and `TransactionManager`.
+
+**Our Adaptation:**
+
+This is the simplest and most powerful pattern to adopt directly. To add BTCC support:
+
+1.  We will create our `BtccFetcher` and `BtccOrderBuilder` classes in `src/protocols/btcc/`.
+2.  We will update `src/protocols/index.js` to import and instantiate these new classes, adding them to the maps returned by `getAllFetchers()` and a new `getAllOrderBuilders()`.
+3.  The `initializer.js` will automatically pick up the new BTCC module with no other changes required.
+
+## 3. Reusable Code and Utilities
+
+Beyond high-level architecture, `AxionCitadel` contains several well-designed, reusable components that we should consider porting to our project to save development time.
+
+*   **Logging (`src/utils/logging/`)**: The Pino-based structured logging service is robust and provides a good foundation for our own logging needs, including dual console/file output.
+*   **Error Handling (`src/core/errors/`)**: The custom error framework (`customErrors.js`, `errorHandler.js`) is essential for building a resilient system. We should adopt this pattern for creating specific, informative errors (e.g., `ApiError`, `OrderExecutionError`).
+*   **Configuration (`src/core/ConfigLoader.js`, `configs/`)**: The configuration management system is well-structured, supporting different environments and chains. We can adapt this to manage our API keys, RPC endpoints, and trading parameters.
+*   **Process Orchestration (`runBot.js`)**: The `runBot.js` script provides a good model for a master process that can manage the core bot, handle logging, and even set up testing conditions.
+
+## 4. Conclusion and Next Steps
+
+The `AxionCitadel` repository is a valuable asset. Its architecture is not only sound but also provides a clear and direct path for our planned CEX integration. By adopting the **Protocol Layer**, **Central Dispatchers**, and **Dynamic Assembly** patterns, we can build a more modular, maintainable, and scalable system.
+
+The immediate next step is to begin implementing the `btcc` protocol module, using the existing DEX modules as a template. This will involve:
+
+1.  Defining the `IBtccFetcher` and `IBtccOrderBuilder` interfaces.
+2.  Implementing the `BtccFetcher` to connect to the BTCC API and retrieve market data.
+3.  Implementing the `BtccOrderBuilder` to handle order creation and management via the API.
+4.  Registering these new components in the `protocols/index.js` registry.
+
+This analysis provides the foundational knowledge and technical blueprint to proceed with confidence.


### PR DESCRIPTION
This commit introduces a detailed analysis of the legacy `AxionCitadel` repository. The analysis is captured in the `AXION_CITADEL_ANALYSIS.md` file.

The document outlines key reusable architectural patterns, including the modular "Protocol Layer," central dispatchers, and dynamic component assembly via a protocol registry. It provides a clear blueprint for how these patterns can be adapted to integrate a centralized exchange (CEX) into our current arbitrage system.

This analysis will serve as a foundational technical guide for the upcoming CEX integration work, saving development time and ensuring a robust, maintainable architecture.