### PR TITLE
feat(btcc): Replace BTCC fetcher with correct Spot API implementation

### DIFF
--- a/gemini-citadel/src/AppController.ts
+++ b/gemini-citadel/src/AppController.ts
@@ -72,13 +72,13 @@ export class AppController {
   }
 
   public async start() {
-    console.log('--- Starting Connection Test ---');
+    console.log('--- Starting NEW Spot API Connection Test ---');
     try {
         const btccFetcher = new BtccCustomFetcher();
-        await btccFetcher.initialize();
-        console.log('--- Connection Test SUCCESSFUL ---');
+        await btccFetcher.testConnection();
+        console.log('--- Spot API Connection Test SUCCESSFUL ---');
     } catch (error) {
-        console.error('--- Connection Test FAILED ---');
+        console.error('--- Spot API Connection Test FAILED ---');
     }
   }
 }

--- a/gemini-citadel/src/protocols/btcc/BtccCustomFetcher.ts
+++ b/gemini-citadel/src/protocols/btcc/BtccCustomFetcher.ts
@@ -3,69 +3,83 @@
 import { IFetcher } from '../../interfaces/IFetcher';
 import axios from 'axios';
 import * as crypto from 'crypto';
+import { stringify } from 'querystring';
 
-const API_BASE_URL = 'https://api1.btloginc.com:9081';
+const API_BASE_URL = 'https://spotapi2.btcccdn.com';
 
 export class BtccCustomFetcher implements IFetcher {
-    private readonly apiKey: string;
-    private readonly apiSecret: string;
-    private readonly username?: string;
-    private readonly password?: string;
-
-    private sessionToken: string | null = null;
-    private accountId: number | null = null;
-    private heartbeatInterval: NodeJS.Timeout | null = null;
+    private readonly accessId: string; // This is your API Key
+    private readonly secretKey: string; // This is your API Secret / Encryption key
 
     constructor() {
-        this.apiKey = process.env.BTCC_API_KEY!;
-        this.apiSecret = process.env.BTCC_API_SECRET!;
-        this.username = process.env.BTCC_USERNAME;
-        this.password = process.env.BTCC_PASSWORD;
+        this.accessId = process.env.BTCC_API_KEY!;
+        this.secretKey = process.env.BTCC_API_SECRET!;
 
-        if (!this.apiKey || !this.apiSecret || !this.username || !this.password) {
-            throw new Error("Missing BTCC credentials in environment variables.");
+        if (!this.accessId || !this.secretKey) {
+            throw new Error("Missing BTCC_API_KEY or BTCC_API_SECRET in environment variables.");
         }
     }
 
     private generateSignature(params: Record<string, any>): string {
-        const tempParams: Record<string, any> = { ...params, secret_key: this.apiSecret };
-        const sortedKeysWithSecret = Object.keys(tempParams).sort();
-        const paramString = sortedKeysWithSecret
-            .map(key => `${key}=${tempParams[key]}`)
-            .join('&');
-
-        return crypto.createHash('md5').update(paramString).digest('hex');
-    }
-
-    public async initialize(): Promise<void> {
-        console.log('[BtccCustomFetcher] Attempting to log in and create session...');
-
-        const loginParams = {
-            user_name: this.username!,
-            password: this.password!,
-            company_id: 1,
-            api_key: this.apiKey
+        // Create a new object with the timestamp and access_id
+        const paramsWithAuth = {
+            ...params,
+            tm: Math.floor(Date.now() / 1000), // Timestamp in seconds
+            access_id: this.accessId,
         };
 
-        const signature = this.generateSignature(loginParams);
+        // 1. Splice parameters (excluding secret_key for now)
+        const paramString = stringify(paramsWithAuth);
 
-        const finalParams = { ...loginParams, sign: signature };
+        // 2. Splice the secret_key
+        const stringToSign = `${paramString}&secret_key=${this.secretKey}`;
+
+        // 3. Sort the final string alphabetically by key
+        const sortedString = stringToSign.split('&').sort().join('&');
+
+        // 4. Get the MD5 value
+        return crypto.createHash('md5').update(sortedString).digest('hex');
+    }
+
+    // A private helper for making signed requests
+    private async makeSignedRequest(method: 'GET' | 'POST', path: string, params: Record<string, any> = {}) {
+        const signature = this.generateSignature(params);
+        const headers = {
+            'authorization': signature
+        };
+
+        // The signature function adds tm and access_id, so we need them in the final request
+        const finalParams = {
+            ...params,
+            tm: Math.floor(Date.now() / 1000),
+            access_id: this.accessId,
+        };
+
+        const url = `${API_BASE_URL}${path}`;
 
         try {
-            const response = await axios.post(`${API_BASE_URL}/v1/user/login`, null, { params: finalParams });
-
-            if (response.data && response.data.code === 0) {
-                this.sessionToken = response.data.token;
-                this.accountId = response.data.account.id;
-                console.log(`[BtccCustomFetcher] Login SUCCESSFUL! Session token and account ID acquired.`);
-                // this.startHeartbeat(); // To be implemented
-            } else {
-                console.error('[BtccCustomFetcher] Login FAILED.', response.data);
-                throw new Error(`BTCC Login Failed: ${response.data.msg || 'Unknown error'}`);
+            if (method === 'GET') {
+                const response = await axios.get(url, { headers, params: finalParams });
+                return response.data;
+            } else { // POST
+                const response = await axios.post(url, finalParams, { headers });
+                return response.data;
             }
         } catch (error: any) {
-            console.error('[BtccCustomFetcher] CRITICAL ERROR during login:', error.response ? error.response.data : error.message);
+            console.error(`[BtccCustomFetcher] API Request FAILED for ${method} ${path}:`, error.response ? error.response.data : error.message);
             throw error;
+        }
+    }
+
+    // A test function to query user assets, which requires a valid signature
+    public async testConnection(): Promise<any> {
+        console.log('[BtccCustomFetcher] Testing connection by querying user assets...');
+        const assetData = await this.makeSignedRequest('GET', '/btcc_api_trade/asset/query');
+        if (assetData && assetData.error === null) {
+            console.log('[BtccCustomFetcher] Asset query successful!', assetData.result);
+            return assetData;
+        } else {
+            throw new Error(`Failed to query assets: ${JSON.stringify(assetData)}`);
         }
     }
 


### PR DESCRIPTION
- Replaced the entire `BtccCustomFetcher` with a new version that correctly implements the stateless BTCC Spot Trading API.
- The new fetcher uses the correct endpoint (`spotapi2.btcccdn.com`) and authentication scheme (MD5 signature with access_id and secret_key).
- Updated the `AppController` to use the new `testConnection` method for verifying the API connection.
- This resolves the `API KEY NOT TRADE AUTH` error caused by using the wrong API (session-based futures API).