### PR TITLE
feat(btcc): implement fetchPrice in BtccCustomFetcher

### DIFF
--- a/gemini-citadel/src/protocols/btcc/BtccCustomFetcher.ts
+++ b/gemini-citadel/src/protocols/btcc/BtccCustomFetcher.ts
@@ -84,6 +84,27 @@ export class BtccCustomFetcher implements IFetcher {
     }
 
     // --- Placeholder implementations for IFetcher interface ---
-    async fetchPrice(pair: string): Promise<number> { return 0; }
+    async fetchPrice(pair: string): Promise<number> {
+        try {
+            console.log(`[BtccCustomFetcher] Fetching price for ${pair}...`);
+            // The API likely expects the pair without any separators, e.g., "BTCUSDT"
+            const symbol = pair.replace('/', '');
+            const data = await this.makeSignedRequest('GET', '/btcc_api_trade/market/detail', { symbol });
+
+            if (data && data.result && typeof data.result.Last === 'number') {
+                console.log(`[BtccCustomFetcher] Successfully fetched price for ${pair}: ${data.result.Last}`);
+                return data.result.Last;
+            } else {
+                // Log the actual data received for diagnostics
+                console.error(`[BtccCustomFetcher] Unexpected response structure for ${pair}:`, data);
+                throw new Error(`Unexpected response structure for ${pair}.`);
+            }
+        } catch (error) {
+            // The makeSignedRequest method already logs the error, so we can just re-throw it.
+            console.error(`[BtccCustomFetcher] Failed to fetch price for ${pair}.`);
+            throw error;
+        }
+    }
+
     async fetchOrderBook(pair: string): Promise<any> { return {}; }
 }

--- a/gemini-citadel/tests/protocols/btcc/BtccCustomFetcher.test.ts
+++ b/gemini-citadel/tests/protocols/btcc/BtccCustomFetcher.test.ts
@@ -1,0 +1,78 @@
+import { BtccCustomFetcher } from '../../../src/protocols/btcc/BtccCustomFetcher';
+import axios from 'axios';
+
+// Mock the axios module
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('BtccCustomFetcher', () => {
+  let fetcher: BtccCustomFetcher;
+
+  // Set up environment variables before each test
+  beforeEach(() => {
+    process.env.BTCC_API_KEY = 'test_key';
+    process.env.BTCC_API_SECRET = 'test_secret';
+    fetcher = new BtccCustomFetcher();
+  });
+
+  // Clear mocks after each test
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchPrice', () => {
+    it('should return the last price for a given pair on successful API call', async () => {
+      const mockPair = 'BTC/USDT';
+      const mockPrice = 50000.12;
+      const mockApiResponse = {
+        result: {
+          Last: mockPrice,
+        },
+        error: null,
+        id: '1',
+      };
+
+      // Mock the GET request to return the successful response
+      mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
+
+      const price = await fetcher.fetchPrice(mockPair);
+
+      expect(price).toEqual(mockPrice);
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+      // Verify that the URL and parameters are correct
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/btcc_api_trade/market/detail'),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            symbol: 'BTCUSDT',
+          }),
+        }),
+      );
+    });
+
+    it('should throw an error if the API response has an unexpected structure', async () => {
+      const mockPair = 'BTC/USDT';
+      const mockApiResponse = {
+        result: {
+          // Missing 'Last' field
+        },
+        error: null,
+      };
+
+      mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
+
+      // We expect the function to throw an error
+      await expect(fetcher.fetchPrice(mockPair)).rejects.toThrow(
+        `Unexpected response structure for ${mockPair}.`
+      );
+    });
+
+    it('should re-throw an error if the axios request fails', async () => {
+        const mockPair = 'BTC/USDT';
+        const errorMessage = 'Network Error';
+        mockedAxios.get.mockRejectedValue(new Error(errorMessage));
+
+        await expect(fetcher.fetchPrice(mockPair)).rejects.toThrow(errorMessage);
+      });
+  });
+});


### PR DESCRIPTION
This commit implements the `fetchPrice` method in the `BtccCustomFetcher` class.

The method makes a signed GET request to the `/btcc_api_trade/market/detail` endpoint of the BTCC Spot API. It extracts the latest price from the `Last` field of the response.

A comprehensive unit test suite is added to verify the functionality, including success cases, handling of malformed responses, and network errors.