### PR TITLE
feat(arbitrage): Integrate Coinbase for Spot Trading

### DIFF
--- a/gemini-citadel/.env.example
+++ b/gemini-citadel/.env.example
@@ -7,6 +7,11 @@ RPC_URL=
 BTCC_API_KEY=
 BTCC_API_SECRET=
 
+# CEX API Credentials for Coinbase
+# IMPORTANT: Fill these in your local .env file. Do not commit the secrets.
+COINBASE_API_KEY=
+COINBASE_API_SECRET=
+
 # Execution Mode: Can be 'DRY_RUN' or 'LIVE'.
 # DRY_RUN will log intended trades without executing them.
 # LIVE will execute real trades. Defaults to DRY_RUN if not set.

--- a/gemini-citadel/src/protocols/coinbase/CoinbaseExecutor.ts
+++ b/gemini-citadel/src/protocols/coinbase/CoinbaseExecutor.ts
@@ -1,0 +1,92 @@
+import { IExecutor } from '../../interfaces/IExecutor';
+import { ITradeAction } from '../../interfaces/ITradeAction';
+import { ITradeReceipt } from '../../interfaces/ITradeReceipt';
+import crypto from 'crypto';
+import axios from 'axios';
+
+const API_BASE_URL = 'https://api.coinbase.com/api/v3/brokerage';
+
+export class CoinbaseExecutor implements IExecutor {
+  private readonly apiKey: string;
+  private readonly apiSecret: string;
+  private readonly executionMode: string;
+
+  constructor() {
+    this.apiKey = process.env.COINBASE_API_KEY || '';
+    this.apiSecret = process.env.COINBASE_API_SECRET || '';
+    this.executionMode = process.env.EXECUTION_MODE || 'DRY_RUN';
+
+    if (!this.apiKey || !this.apiSecret) {
+      throw new Error('Coinbase API key and secret must be provided in environment variables.');
+    }
+  }
+
+  private createSignature(timestamp: string, method: string, requestPath: string, body: string): string {
+    const message = timestamp + method.toUpperCase() + requestPath + body;
+    return crypto.createHmac('sha256', this.apiSecret).update(message).digest('hex');
+  }
+
+  private async makeSignedRequest(method: string, path: string, body: any = {}): Promise<any> {
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const bodyString = JSON.stringify(body);
+    const signature = this.createSignature(timestamp, method, path, bodyString);
+
+    const headers = {
+      'CB-ACCESS-KEY': this.apiKey,
+      'CB-ACCESS-SIGN': signature,
+      'CB-ACCESS-TIMESTAMP': timestamp,
+      'Content-Type': 'application/json',
+    };
+
+    const url = `${API_BASE_URL}${path}`;
+
+    try {
+      const response = await axios({
+        method,
+        url,
+        headers,
+        data: bodyString,
+      });
+      return response.data;
+    } catch (error: any) {
+      console.error(`[CoinbaseExecutor] API Request FAILED for ${method} ${path}:`, error.response ? error.response.data : error.message);
+      throw error;
+    }
+  }
+
+  public async placeOrder(action: ITradeAction): Promise<ITradeReceipt> {
+    const { pair, action: tradeAction, price, amount } = action;
+
+    const requestBody = {
+      product_id: pair,
+      side: tradeAction.toUpperCase(),
+      base_size: amount.toString(), // Coinbase uses base_size for amount
+      limit_price: price.toString(),
+      order_type: 'LIMIT',
+    };
+
+    if (this.executionMode === 'DRY_RUN') {
+      console.log('[CoinbaseExecutor][DRY_RUN] Would place the following order:');
+      console.log(JSON.stringify(requestBody, null, 2));
+
+      return {
+        success: true,
+        orderId: `dry-run-${Date.now()}`,
+        filledAmount: amount,
+        message: 'Dry run execution successful.',
+      };
+    } else if (this.executionMode === 'LIVE') {
+      console.log('[CoinbaseExecutor][LIVE] Placing real order...');
+      const response = await this.makeSignedRequest('POST', '/orders', requestBody);
+
+      return {
+        success: response.success,
+        orderId: response.order_id,
+        filledAmount: parseFloat(response.filled_size || '0'),
+        message: response.message || `Live execution response: ${response.order_id}`,
+      };
+    } else {
+      throw new Error(`Invalid EXECUTION_MODE: ${this.executionMode}. Must be 'DRY_RUN' or 'LIVE'.`);
+    }
+  }
+}

--- a/gemini-citadel/src/protocols/coinbase/CoinbaseFetcher.ts
+++ b/gemini-citadel/src/protocols/coinbase/CoinbaseFetcher.ts
@@ -1,0 +1,50 @@
+import { IFetcher } from '../../interfaces/IFetcher';
+import axios from 'axios';
+
+const API_BASE_URL = 'https://api.coinbase.com/api/v3/brokerage';
+
+export class CoinbaseFetcher implements IFetcher {
+    constructor() {
+        // No-op
+    }
+
+    private async makePublicRequest(path: string, params: Record<string, any> = {}) {
+        const url = `${API_BASE_URL}${path}`;
+        try {
+            const response = await axios.get(url, { params });
+            return response.data;
+        } catch (error: any) {
+            console.error(`[CoinbaseFetcher] API Request FAILED for GET ${path}:`, error.response ? error.response.data : error.message);
+            throw error;
+        }
+    }
+
+    async fetchPrice(pair: string): Promise<number> {
+        // Coinbase API uses '-' as a separator, e.g., 'BTC-USD'
+        if (!pair.includes('-')) {
+            throw new Error(`Invalid pair format for Coinbase: ${pair}. Expected format like 'BTC-USD'.`);
+        }
+        try {
+            console.log(`[CoinbaseFetcher] Fetching price for ${pair}...`);
+            // The Advanced Trade API uses product_id for pairs
+            const data = await this.makePublicRequest(`/products/${pair}`);
+
+            if (data && typeof data.price === 'string') {
+                const price = parseFloat(data.price);
+                console.log(`[CoinbaseFetcher] Successfully fetched price for ${pair}: ${price}`);
+                return price;
+            } else {
+                console.error(`[CoinbaseFetcher] Unexpected response structure for ${pair}:`, data);
+                throw new Error(`Unexpected response structure for ${pair}.`);
+            }
+        } catch (error) {
+            console.error(`[CoinbaseFetcher] Failed to fetch price for ${pair}.`);
+            throw error;
+        }
+    }
+
+    async fetchOrderBook(pair: string): Promise<any> {
+        // This method is not required for the current task.
+        return {};
+    }
+}

--- a/gemini-citadel/tests/protocols/coinbase/Coinbase.test.ts
+++ b/gemini-citadel/tests/protocols/coinbase/Coinbase.test.ts
@@ -1,0 +1,113 @@
+import { CoinbaseFetcher } from '../../../src/protocols/coinbase/CoinbaseFetcher';
+import { CoinbaseExecutor } from '../../../src/protocols/coinbase/CoinbaseExecutor';
+import { ITradeAction } from '../../../src/interfaces/ITradeAction';
+import axios from 'axios';
+
+// Mock axios to avoid actual API calls
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('CoinbaseFetcher', () => {
+    let fetcher: CoinbaseFetcher;
+
+    beforeEach(() => {
+        fetcher = new CoinbaseFetcher();
+        mockedAxios.get.mockClear();
+    });
+
+    it('should fetch the price for a valid pair', async () => {
+        const mockResponse = { data: { price: '50000.00' } };
+        mockedAxios.get.mockResolvedValue(mockResponse);
+
+        const price = await fetcher.fetchPrice('BTC-USD');
+
+        expect(price).toBe(50000.00);
+        expect(mockedAxios.get).toHaveBeenCalledWith(
+            'https://api.coinbase.com/api/v3/brokerage/products/BTC-USD',
+            { params: {} }
+        );
+    });
+
+    it('should throw an error for an invalid pair format', async () => {
+        await expect(fetcher.fetchPrice('BTCUSD')).rejects.toThrow(
+            "Invalid pair format for Coinbase: BTCUSD. Expected format like 'BTC-USD'."
+        );
+    });
+
+    it('should throw an error if the API response is malformed', async () => {
+        const mockResponse = { data: { value: '50000.00' } }; // 'value' instead of 'price'
+        mockedAxios.get.mockResolvedValue(mockResponse);
+
+        await expect(fetcher.fetchPrice('BTC-USD')).rejects.toThrow(
+            'Unexpected response structure for BTC-USD.'
+        );
+    });
+});
+
+describe('CoinbaseExecutor', () => {
+    let executor: CoinbaseExecutor;
+
+    const mockAction: ITradeAction = {
+        exchange: 'coinbase',
+        pair: 'BTC-USD',
+        action: 'Buy',
+        price: 50000,
+        amount: 0.1,
+    };
+
+    beforeEach(() => {
+        // Set up mock environment variables
+        process.env.COINBASE_API_KEY = 'test-key';
+        process.env.COINBASE_API_SECRET = 'test-secret';
+        process.env.EXECUTION_MODE = 'DRY_RUN'; // Default to DRY_RUN for safety
+
+        executor = new CoinbaseExecutor();
+        // Correctly clear the mock for the main axios function
+        (axios as unknown as jest.Mock).mockClear();
+    });
+
+    it('should correctly log a DRY_RUN order', async () => {
+        const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+        const receipt = await executor.placeOrder(mockAction);
+
+        expect(receipt.success).toBe(true);
+        expect(receipt.orderId).toContain('dry-run-');
+        expect(consoleSpy).toHaveBeenCalledWith('[CoinbaseExecutor][DRY_RUN] Would place the following order:');
+
+        consoleSpy.mockRestore();
+    });
+
+    it('should execute a LIVE order', async () => {
+        process.env.EXECUTION_MODE = 'LIVE';
+        executor = new CoinbaseExecutor(); // Re-initialize to pick up new EXECUTION_MODE
+
+        const mockApiResponse = {
+            data: {
+                success: true,
+                order_id: 'live-order-123',
+                filled_size: '0.1',
+            }
+        };
+        (axios as unknown as jest.Mock).mockResolvedValue(mockApiResponse);
+
+        const receipt = await executor.placeOrder(mockAction);
+
+        expect(receipt.success).toBe(true);
+        expect(receipt.orderId).toBe('live-order-123');
+        expect(receipt.filledAmount).toBe(0.1);
+        expect(axios).toHaveBeenCalledTimes(1);
+        const axiosCall = (axios as unknown as jest.Mock).mock.calls[0][0];
+        expect(axiosCall.method).toBe('POST');
+        expect(axiosCall.url).toContain('/orders');
+        expect(axiosCall.headers).toHaveProperty('CB-ACCESS-KEY', 'test-key');
+        expect(axiosCall.headers).toHaveProperty('CB-ACCESS-SIGN');
+    });
+
+    it('should throw an error if API keys are missing', () => {
+        delete process.env.COINBASE_API_KEY;
+        delete process.env.COINBASE_API_SECRET;
+
+        expect(() => new CoinbaseExecutor()).toThrow('Coinbase API key and secret must be provided in environment variables.');
+    });
+});


### PR DESCRIPTION
This change integrates Coinbase into the spot arbitrage engine, making the system more robust and exchange-agnostic.

It introduces:
- A `CoinbaseFetcher` to retrieve spot prices from the Coinbase Advanced Trade API.
- A `CoinbaseExecutor` to place orders, with support for both `DRY_RUN` and `LIVE` modes. This includes the necessary authentication and request signing logic.
- Comprehensive unit tests for both the fetcher and executor, mocking API calls to ensure correctness.

The `.env.example` file has been updated to include the new `COINBASE_API_KEY` and `COINBASE_API_SECRET` variables.