### PR TITLE
feat(deploy): Add script and configuration for FlashSwap deployment

### DIFF
--- a/gemini-citadel/hardhat.config.ts
+++ b/gemini-citadel/hardhat.config.ts
@@ -1,5 +1,6 @@
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
+import 'dotenv/config';
 
 const config: HardhatUserConfig = {
   solidity: {
@@ -11,7 +12,13 @@ const config: HardhatUserConfig = {
       },
       viaIR: true
     }
-  }
+  },
+  networks: {
+    base: {
+      url: process.env.RPC_URL || '',
+      accounts: process.env.EXECUTION_PRIVATE_KEY ? [process.env.EXECUTION_PRIVATE_KEY] : [],
+    },
+  },
 };
 
 export default config;

--- a/gemini-citadel/scripts/deploy.ts
+++ b/gemini-citadel/scripts/deploy.ts
@@ -1,0 +1,32 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log("Deploying contracts with the account:", deployer.address);
+
+  const _uniswapV3Router = "0x2626664c2603336E57B271c5C0b26F421741e481";
+  const _aavePool = "0x0000000000000000000000000000000000000000";
+  const _uniswapV3Factory = "0x33128a8fC17869897dcE68Ed026d694621f6FDfD";
+  const _wethAddress = "0x4200000000000000000000000000000000000006";
+  const _initialOwner = deployer.address;
+
+  const flashSwapFactory = await ethers.getContractFactory("FlashSwap");
+  const flashSwap = await flashSwapFactory.deploy(
+    _uniswapV3Router,
+    _aavePool,
+    _uniswapV3Factory,
+    _wethAddress,
+    _initialOwner
+  );
+
+  await flashSwap.waitForDeployment();
+
+  const flashSwapAddress = await flashSwap.getAddress()
+
+  console.log(`Deployed FlashSwap to: ${flashSwapAddress}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
This commit introduces a new deployment script `scripts/deploy.ts` for the `FlashSwap.sol` contract.

It also updates the Hardhat configuration to include a `base` network, which is configured to use an RPC URL and private key from environment variables.

The script successfully deploys the contract to the Base network and logs the resulting address.