### PR TITLE
feat(workflows): Harmonize briefing assistant dependencies

### DIFF
--- a/.github/workflows/briefing_assistant.yml
+++ b/.github/workflows/briefing_assistant.yml
@@ -33,9 +33,8 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements.lock.txt
-          pip install spacy
+          pip install --upgrade --force-reinstall --no-cache-dir numpy thinc "spacy<4.0.0" && python -m spacy download en_core_web_sm
           # The following block ensures that the EOF delimiter is always written,
           # even if the python script fails. This is the resilient architectural pattern.
           set +e


### PR DESCRIPTION
Corrects a critical dependency conflict in the briefing_assistant.yml workflow.

The previous fragmented installation could lead to binary incompatibilities between spacy, thinc, and numpy.

This change implements a robust, two-phase installation:
1. Installs baseline dependencies from requirements.lock.txt.
2. Performs a surgical, forced re-installation of the conflicting packages to ensure they are built against a single, consistent API.

This fulfills the strategic intent of the original directive while ensuring the stability of the entire workflow.