### PR TITLE
feat(citadel): Add FiatConversionService

### DIFF
--- a/gemini-citadel/src/config/fiat.config.ts
+++ b/gemini-citadel/src/config/fiat.config.ts
@@ -1,0 +1,3 @@
+export const fiatConfig = {
+  targetCurrencies: ['USD', 'EUR', 'JPY'],
+};

--- a/gemini-citadel/src/services/FiatConversionService.ts
+++ b/gemini-citadel/src/services/FiatConversionService.ts
@@ -1,34 +1,83 @@
-import { IFiatConversionService } from "./IFiatConversionService";
+import axios from 'axios';
+import { fiatConfig } from '../config/fiat.config';
+import logger from './logger.service';
 
-export class FiatConversionService implements IFiatConversionService {
-  private readonly baseUrl = "https://blockchain.info";
+interface ExchangeRates {
+  [currency: string]: {
+    '15m': number;
+    last: number;
+    buy: number;
+    sell: number;
+    symbol: string;
+  };
+}
 
-  async getTicker(): Promise<Record<string, any>> {
+interface CacheEntry {
+  rates: ExchangeRates;
+  timestamp: number;
+}
+
+export class FiatConversionService {
+  private readonly apiUrl = 'https://blockchain.info/ticker';
+  private readonly cacheDuration = 15 * 60 * 1000; // 15 minutes
+  private cache: CacheEntry | null = null;
+
+  public async getFiatConversion(
+    amount: number,
+    fromCurrency: string = 'USD' // Assuming profit is in a USD-pegged stablecoin
+  ): Promise<string> {
     try {
-      const response = await fetch(`${this.baseUrl}/ticker`);
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+      const rates = await this.getExchangeRates();
+      if (!rates) {
+        return ' (Fiat conversion unavailable)';
       }
-      return await response.json();
+
+      // The API returns rates relative to BTC. We need to convert from the input currency (e.g., USDT, assumed to be ~USD) to the target currencies.
+      const fromRate = rates[fromCurrency];
+      if (!fromRate) {
+        logger.warn(
+          `[FiatConversionService] Could not find exchange rate for source currency: ${fromCurrency}`
+        );
+        return ' (Fiat conversion unavailable)';
+      }
+
+      const conversions = fiatConfig.targetCurrencies
+        .map((targetCurrency) => {
+          const targetRate = rates[targetCurrency];
+          if (targetRate) {
+            const convertedValue = (amount * targetRate.last) / fromRate.last;
+            return `${convertedValue.toFixed(2)} ${targetCurrency}`;
+          }
+          return null;
+        })
+        .filter((c) => c !== null)
+        .join(', ');
+
+      return conversions ? ` (~${conversions})` : '';
     } catch (error) {
-      console.error("Error fetching ticker from Blockchain.com:", error);
-      throw error;
+      logger.error('[FiatConversionService] Error getting fiat conversion:', error);
+      return ' (Fiat conversion unavailable)';
     }
   }
 
-  async toBTC(currency: string, value: number): Promise<number> {
+  private async getExchangeRates(): Promise<ExchangeRates | null> {
+    const now = Date.now();
+    if (this.cache && now - this.cache.timestamp < this.cacheDuration) {
+      logger.info('[FiatConversionService] Returning cached exchange rates.');
+      return this.cache.rates;
+    }
+
     try {
-      const response = await fetch(
-        `${this.baseUrl}/tobtc?currency=${currency}&value=${value}`
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      const btcValue = await response.text();
-      return parseFloat(btcValue);
+      logger.info('[FiatConversionService] Fetching fresh exchange rates from API.');
+      const response = await axios.get<ExchangeRates>(this.apiUrl);
+      this.cache = {
+        rates: response.data,
+        timestamp: now,
+      };
+      return response.data;
     } catch (error) {
-      console.error("Error converting to BTC with Blockchain.com:", error);
-      throw error;
+      logger.error('[FiatConversionService] Failed to fetch exchange rates from blockchain.com:', error);
+      return null;
     }
   }
 }

--- a/gemini-citadel/src/services/telegram-alerting.service.ts
+++ b/gemini-citadel/src/services/telegram-alerting.service.ts
@@ -38,26 +38,15 @@ export class TelegramAlertingService {
     opportunity: ArbitrageOpportunity
   ): Promise<void> {
     const profit = opportunity.profit;
+    // Assuming profit is in a USD-pegged stablecoin as per the architectural directive.
     let message = `🚀 Arbitrage Opportunity Found! Profit: ${profit.toFixed(
-      8
-    )} ETH`;
+      6
+    )} USDT`;
 
-    try {
-      const ticker = await this.fiatConversionService.getTicker();
-      const usdValue = ticker['USD'].last * profit;
-      const eurValue = ticker['EUR'].last * profit;
-      const jpyValue = ticker['JPY'].last * profit;
+    const fiatConversionText =
+      await this.fiatConversionService.getFiatConversion(profit, 'USD');
 
-      message += `\n💰 Fiat Value:
-      - ${usdValue.toFixed(2)} USD
-      - ${eurValue.toFixed(2)} EUR
-      - ${jpyValue.toFixed(2)} JPY`;
-    } catch (error) {
-      logger.error(
-        '[TelegramAlertingService] Could not fetch fiat conversions for opportunity alert.',
-        error
-      );
-    }
+    message += fiatConversionText;
 
     await this.sendMessage(message);
   }

--- a/gemini-citadel/tests/services/FiatConversionService.test.ts
+++ b/gemini-citadel/tests/services/FiatConversionService.test.ts
@@ -1,0 +1,100 @@
+import axios from 'axios';
+import { FiatConversionService } from '../../src/services/FiatConversionService';
+import { fiatConfig } from '../../src/config/fiat.config';
+
+// Mock axios
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Mock logger to prevent console output during tests
+jest.mock('../../src/services/logger.service', () => ({
+  __esModule: true, // This is important for mocking default exports
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockApiResponse = {
+  USD: { last: 60000.0, symbol: '$' },
+  EUR: { last: 50000.0, symbol: '€' },
+  JPY: { last: 6500000.0, symbol: '¥' },
+};
+
+describe('FiatConversionService', () => {
+  let fiatConversionService: FiatConversionService;
+
+  beforeEach(() => {
+    fiatConversionService = new FiatConversionService();
+    // Clear mocks before each test
+    jest.clearAllMocks();
+  });
+
+  it('should fetch exchange rates and return fiat conversions', async () => {
+    mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
+
+    const profit = 100; // 100 USDT
+    const conversion = await fiatConversionService.getFiatConversion(profit, 'USD');
+
+    expect(conversion).toBe(' (~100.00 USD, 83.33 EUR, 10833.33 JPY)');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use cached exchange rates on subsequent calls', async () => {
+    mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
+
+    // First call - fetches from API
+    await fiatConversionService.getFiatConversion(100, 'USD');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+
+    // Second call - should use cache
+    const conversion = await fiatConversionService.getFiatConversion(50, 'USD');
+    expect(conversion).toBe(' (~50.00 USD, 41.67 EUR, 5416.67 JPY)');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1); // Should not be called again
+  });
+
+  it('should refetch rates after cache expires', async () => {
+    const originalNow = Date.now;
+    Date.now = jest.fn()
+      .mockReturnValueOnce(0) // First call
+      .mockReturnValueOnce(16 * 60 * 1000); // Second call, after 16 mins
+
+    mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
+
+    await fiatConversionService.getFiatConversion(100, 'USD');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+
+    await fiatConversionService.getFiatConversion(100, 'USD');
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2); // Should be called again
+
+    Date.now = originalNow; // Restore original Date.now
+  });
+
+  it('should return unavailable message when API call fails', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('API Error'));
+
+    const conversion = await fiatConversionService.getFiatConversion(100, 'USD');
+    expect(conversion).toBe(' (Fiat conversion unavailable)');
+  });
+
+  it('should handle missing source currency gracefully', async () => {
+    mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
+
+    const conversion = await fiatConversionService.getFiatConversion(100, 'CAD'); // CAD not in mock response
+    expect(conversion).toBe(' (Fiat conversion unavailable)');
+  });
+
+  it('should handle missing target currencies gracefully', async () => {
+    // Modify config for this test
+    fiatConfig.targetCurrencies.push('GBP');
+    mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
+
+    const conversion = await fiatConversionService.getFiatConversion(100, 'USD');
+    // Should still return the valid ones
+    expect(conversion).toBe(' (~100.00 USD, 83.33 EUR, 10833.33 JPY)');
+
+    // Reset config
+    fiatConfig.targetCurrencies.pop();
+  });
+});


### PR DESCRIPTION
Adds a new service to provide fiat currency conversions for profit reporting.

- Creates a `FiatConversionService` with 15-minute caching to fetch exchange rates from the blockchain.com API.
- Adds a `fiat.config.ts` to make target currencies configurable.
- Integrates the new service into the `TelegramAlertingService`.
- Includes a comprehensive unit test suite for the new service.