### PR TITLE
feat(gemini-citadel): Create FiatConversionService

### DIFF
--- a/gemini-citadel/src/config/fiat.config.ts
+++ b/gemini-citadel/src/config/fiat.config.ts
@@ -1,3 +1,1 @@
-export const fiatConfig = {
-  targetCurrencies: ['USD', 'EUR', 'JPY'],
-};
+export const FIAT_CURRENCIES = ['USD', 'EUR', 'GBP'];

--- a/gemini-citadel/tests/services/FiatConversionService.test.ts
+++ b/gemini-citadel/tests/services/FiatConversionService.test.ts
@@ -1,100 +1,89 @@
 import axios from 'axios';
-import { FiatConversionService } from '../../src/services/FiatConversionService';
-import { fiatConfig } from '../../src/config/fiat.config';
+import { fiatConversionService } from '../../src/services/FiatConversionService';
+import logger from '../../src/services/logger.service';
 
-// Mock axios
 jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('../../src/services/logger.service');
 
-// Mock logger to prevent console output during tests
-jest.mock('../../src/services/logger.service', () => ({
-  __esModule: true, // This is important for mocking default exports
-  default: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  },
-}));
-
-const mockApiResponse = {
-  USD: { last: 60000.0, symbol: '$' },
-  EUR: { last: 50000.0, symbol: '€' },
-  JPY: { last: 6500000.0, symbol: '¥' },
-};
+const mockApiData = [
+  { symbol: 'BTC-USD', last_trade_price: 50000.0, price_24h: 49000, volume_24h: 1000 },
+  { symbol: 'BTC-EUR', last_trade_price: 45000.0, price_24h: 44000, volume_24h: 900 },
+  { symbol: 'BTC-GBP', last_trade_price: 40000.0, price_24h: 39000, volume_24h: 800 },
+];
 
 describe('FiatConversionService', () => {
-  let fiatConversionService: FiatConversionService;
+  let mockedAxios: jest.Mocked<typeof axios>;
+  let service: typeof fiatConversionService;
 
   beforeEach(() => {
-    fiatConversionService = new FiatConversionService();
-    // Clear mocks before each test
-    jest.clearAllMocks();
+    // Reset the singleton's state before each test
+    service = new (fiatConversionService as any).constructor();
+
+    mockedAxios = axios as jest.Mocked<typeof axios>;
+    mockedAxios.get.mockClear();
+    (logger.info as jest.Mock).mockClear();
+    (logger.error as jest.Mock).mockClear();
   });
 
-  it('should fetch exchange rates and return fiat conversions', async () => {
-    mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
+  it('should not fetch rates on initialization', () => {
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
 
-    const profit = 100; // 100 USDT
-    const conversion = await fiatConversionService.getFiatConversion(profit, 'USD');
+  it('should fetch and cache rates on the first call', async () => {
+    mockedAxios.get.mockResolvedValue({ data: mockApiData });
 
-    expect(conversion).toBe(' (~100.00 USD, 83.33 EUR, 10833.33 JPY)');
+    const rate = await service.getConversionRate('USD');
+
+    expect(rate).toBe(50000.0);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('Successfully updated fiat conversion rates.');
+  });
+
+  it('should use cache for subsequent calls within the cache duration', async () => {
+    mockedAxios.get.mockResolvedValue({ data: mockApiData });
+
+    await service.getConversionRate('USD'); // First call
+    const rate = await service.getConversionRate('USD'); // Second call
+
+    expect(rate).toBe(50000.0);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1); // Should not fetch again
+  });
+
+  it('should return null for an unsupported currency', async () => {
+    mockedAxios.get.mockResolvedValue({ data: mockApiData });
+
+    const rate = await service.getConversionRate('JPY');
+    expect(rate).toBeNull();
     expect(mockedAxios.get).toHaveBeenCalledTimes(1);
   });
 
-  it('should use cached exchange rates on subsequent calls', async () => {
-    mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
-
-    // First call - fetches from API
-    await fiatConversionService.getFiatConversion(100, 'USD');
-    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
-
-    // Second call - should use cache
-    const conversion = await fiatConversionService.getFiatConversion(50, 'USD');
-    expect(conversion).toBe(' (~50.00 USD, 41.67 EUR, 5416.67 JPY)');
-    expect(mockedAxios.get).toHaveBeenCalledTimes(1); // Should not be called again
-  });
-
-  it('should refetch rates after cache expires', async () => {
-    const originalNow = Date.now;
-    Date.now = jest.fn()
-      .mockReturnValueOnce(0) // First call
-      .mockReturnValueOnce(16 * 60 * 1000); // Second call, after 16 mins
-
-    mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
-
-    await fiatConversionService.getFiatConversion(100, 'USD');
-    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
-
-    await fiatConversionService.getFiatConversion(100, 'USD');
-    expect(mockedAxios.get).toHaveBeenCalledTimes(2); // Should be called again
-
-    Date.now = originalNow; // Restore original Date.now
-  });
-
-  it('should return unavailable message when API call fails', async () => {
+  it('should handle API errors gracefully', async () => {
     mockedAxios.get.mockRejectedValue(new Error('API Error'));
 
-    const conversion = await fiatConversionService.getFiatConversion(100, 'USD');
-    expect(conversion).toBe(' (Fiat conversion unavailable)');
+    const rate = await service.getConversionRate('USD');
+
+    expect(rate).toBeNull();
+    expect(logger.error).toHaveBeenCalledWith('Failed to update fiat conversion rates:', expect.any(Error));
   });
 
-  it('should handle missing source currency gracefully', async () => {
-    mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
+  it('should refetch data if cache is expired', async () => {
+    mockedAxios.get.mockResolvedValue({ data: mockApiData });
 
-    const conversion = await fiatConversionService.getFiatConversion(100, 'CAD'); // CAD not in mock response
-    expect(conversion).toBe(' (Fiat conversion unavailable)');
-  });
+    // Initial fetch
+    let rate = await service.getConversionRate('USD');
+    expect(rate).toBe(50000.0);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
 
-  it('should handle missing target currencies gracefully', async () => {
-    // Modify config for this test
-    fiatConfig.targetCurrencies.push('GBP');
-    mockedAxios.get.mockResolvedValue({ data: mockApiResponse });
+    // Expire cache by manipulating time
+    const CACHE_DURATION_MS = 15 * 60 * 1000;
+    (service as any).cache['USD'].timestamp = Date.now() - CACHE_DURATION_MS - 1;
 
-    const conversion = await fiatConversionService.getFiatConversion(100, 'USD');
-    // Should still return the valid ones
-    expect(conversion).toBe(' (~100.00 USD, 83.33 EUR, 10833.33 JPY)');
+    // This call should trigger a refetch
+    const updatedMockData = mockApiData.map(d => ({ ...d, last_trade_price: d.last_trade_price + 100 }));
+    mockedAxios.get.mockResolvedValue({ data: updatedMockData });
 
-    // Reset config
-    fiatConfig.targetCurrencies.pop();
+    rate = await service.getConversionRate('USD');
+    expect(rate).toBe(50100.0);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
This commit introduces the FiatConversionService, a new component responsible for fetching and caching fiat currency conversion rates from the blockchain.com API.

The service is designed with a lazy-loading pattern to avoid asynchronous operations in the constructor, and it includes a 15-minute caching layer to optimize performance. It loads its target currencies from a dedicated configuration file and includes robust error handling.

Comprehensive unit tests have been added to verify the service's functionality, including data fetching, caching, cache expiration, and error handling.