### PR TITLE
feat(sync-env): Implement persistent pip cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ nohup.out
 *.report.md
 *.txt!requirements.lock.txt
 .keystone_checksums
+.pip_cache/

--- a/sync-env.sh
+++ b/sync-env.sh
@@ -91,14 +91,14 @@ fi
 
 if [ "$FORCE_REINSTALL" = true ]; then
     echo ">>> --force-reinstall flag detected. Forcing re-installation of Python dependencies."
-    find . -name 'requirements.txt' -not -path './Aegis/*' -exec pip install -r {} \;
+    find . -name 'requirements.txt' -not -path './Aegis/*' -exec pip install --cache-dir .pip_cache -r {} \;
     echo "$CURRENT_CHECKSUM" > "$CHECKSUM_FILE"
     echo "✅ Python dependencies re-installed and checksum updated."
 elif [ "$CURRENT_CHECKSUM" = "$PREVIOUS_CHECKSUM" ]; then
     echo "✅ Python dependencies are already in sync. Skipping."
 else
     echo ">>> Checksum mismatch or first run. Installing Python dependencies."
-    find . -name 'requirements.txt' -not -path './Aegis/*' -exec pip install -r {} \;
+    find . -name 'requirements.txt' -not -path './Aegis/*' -exec pip install --cache-dir .pip_cache -r {} \;
     echo "$CURRENT_CHECKSUM" > "$CHECKSUM_FILE"
     echo "✅ Python dependencies synchronized and checksum updated."
 fi


### PR DESCRIPTION
- Adds a persistent local pip cache (`.pip_cache/`) to the `sync-env.sh` script.
- This mitigates the performance bottleneck caused by the ephemeral execution environment, which was forcing a full dependency re-installation on every run.
- Updates `.gitignore` to exclude the new cache directory.