### PR TITLE
I have modified the `setup-aegis.sh` script to include a `--skip-pyth…

### DIFF
--- a/setup-aegis.sh
+++ b/setup-aegis.sh
@@ -3,13 +3,23 @@
 # A single, canonical script to create a stable, snapshot-ready environment.
 set -e # Exit immediately if a command fails
 
+# --- Argument Parsing ---
+SKIP_PYTHON=false
+if [ "$1" == "--skip-python" ]; then
+    SKIP_PYTHON=true
+fi
+
 echo "--- [Aegis] Starting Full Environment Setup ---"
 
 # --- 1. Synchronize Python Dependencies ---
-echo "--- [Aegis] Step: Installing Python Dependencies..."
-# We remove the checksum logic as this is a one-time clean install.
-find . -name 'requirements.txt' -not -path './Aegis/*' -exec pip install -r {} \;
-echo "--- [Aegis] ✅ Python Dependencies Installed."
+if [ "$SKIP_PYTHON" = false ]; then
+    echo "--- [Aegis] Step: Installing Python Dependencies..."
+    # We remove the checksum logic as this is a one-time clean install.
+    find . -name 'requirements.txt' -not -path './Aegis/*' -exec pip install -r {} \;
+    echo "--- [Aegis] ✅ Python Dependencies Installed."
+else
+    echo "--- [Aegis] Step: Installing Python Dependencies... (SKIPPED)"
+fi
 
 # --- 2. Synchronize Node.js Dependencies ---
 echo ""


### PR DESCRIPTION
…on` flag that conditionally skips the Python dependency installation.

The script now correctly skips the Python dependency installation when the `--skip-python` flag is provided, and installs them otherwise.