### PR TITLE
feat(gemini-citadel): Integrate PROJECT-HAVOC core engine

### DIFF
--- a/gemini-citadel/src/AppController.ts
+++ b/gemini-citadel/src/AppController.ts
@@ -1,6 +1,5 @@
 import 'dotenv/config';
 import { Wallet, JsonRpcProvider } from 'ethers';
-import { StrategyEngine } from './services/strategy.service';
 import { CexStrategyEngine } from './services/CexStrategyEngine';
 import { ExchangeDataProvider } from './services/ExchangeDataProvider';
 import { ExecutionManager } from './services/ExecutionManager';
@@ -9,16 +8,14 @@ import { TelegramAlertingService } from './services/telegram-alerting.service';
 import { MarketIntelligenceService } from './services/MarketIntelligenceService';
 import { botConfig } from './config/bot.config';
 import logger from './services/logger.service';
-import { UniswapV3Fetcher } from './havoc-core/core/fetchers/UniswapV3Fetcher';
-import { BASE_TOKENS } from './havoc-core/constants/tokens';
 import { ArbitrageEngine } from './havoc-core/core/ArbitrageEngine';
 import { Token } from '@uniswap/sdk-core';
 import { ArbitrageOpportunity } from './models/ArbitrageOpportunity';
+import { BASE_TOKENS } from './havoc-core/constants/tokens';
 
 export class AppController {
   private readonly exchangeDataProvider: ExchangeDataProvider;
   private readonly executionManager: ExecutionManager;
-  private readonly strategyEngine: StrategyEngine; // For DEX
   private readonly cexStrategyEngine: CexStrategyEngine; // For CEX
   private readonly flashbotsService: FlashbotsService;
   private readonly telegramAlertingService: TelegramAlertingService;
@@ -29,7 +26,6 @@ export class AppController {
   constructor(
     dataProvider: ExchangeDataProvider,
     executionManager: ExecutionManager,
-    strategyEngine: StrategyEngine,
     flashbotsService: FlashbotsService,
     cexStrategyEngine: CexStrategyEngine,
     telegramAlertingService: TelegramAlertingService,
@@ -38,7 +34,6 @@ export class AppController {
   ) {
     this.exchangeDataProvider = dataProvider;
     this.executionManager = executionManager;
-    this.strategyEngine = strategyEngine;
     this.flashbotsService = flashbotsService;
     this.cexStrategyEngine = cexStrategyEngine;
     this.telegramAlertingService = telegramAlertingService;

--- a/gemini-citadel/src/AppFactory.ts
+++ b/gemini-citadel/src/AppFactory.ts
@@ -1,6 +1,5 @@
 import { Wallet, JsonRpcProvider } from 'ethers';
 import { AppController } from './AppController';
-import { StrategyEngine } from './services/strategy.service';
 import { ExchangeDataProvider } from './services/ExchangeDataProvider';
 import { ExecutionManager } from './services/ExecutionManager';
 import { FlashbotsService } from './services/FlashbotsService';
@@ -32,7 +31,6 @@ export class AppFactory {
     const flashbotsService = new FlashbotsService(provider, executionSigner);
     await flashbotsService.initialize();
     const executionManager = new ExecutionManager(flashbotsService, executionSigner, dataProvider);
-    const strategyEngine = new StrategyEngine(dataProvider);
     const cexStrategyEngine = new CexStrategyEngine(dataProvider);
     const fiatConversionService = new FiatConversionService();
     const telegramAlertingService = new TelegramAlertingService(
@@ -47,15 +45,14 @@ export class AppFactory {
     const arbitrageEngine = new ArbitrageEngine(provider, uniswapV3Fetcher);
 
     // --- Protocol Initialization ---
-    // (This loop can be removed if we are not using the old CEX fetcher system for now)
     for (const exchangeConfig of botConfig.exchanges) {
       if (exchangeConfig.enabled && exchangeConfig.type === 'CEX') {
         const cexFetcher = new CcxtFetcher(
-          exchangeConfig.name,
-          exchangeConfig.apiKey,
-          exchangeConfig.apiSecret
+          exchange.name,
+          exchange.apiKey,
+          exchange.apiSecret
         );
-        dataProvider.registerCexFetcher(exchangeConfig.name, cexFetcher, exchangeConfig.fee);
+        dataProvider.registerCexFetcher(exchange.name, cexFetcher, exchange.fee);
       }
     }
 
@@ -63,7 +60,6 @@ export class AppFactory {
     return new AppController(
       dataProvider,
       executionManager,
-      strategyEngine,
       flashbotsService,
       cexStrategyEngine,
       telegramAlertingService,

--- a/gemini-citadel/test/integration/Havoc.integration.test.ts
+++ b/gemini-citadel/test/integration/Havoc.integration.test.ts
@@ -20,9 +20,8 @@ describe('Havoc Integration Test', () => {
     appController = await AppFactory.create();
   });
 
-  it('should successfully fetch live pool data from a forked Base mainnet', async () => {
-    // We will call the runDexCycle method, which now contains our integrated UniswapV3Fetcher
-    // This will attempt to fetch data for the WETH/USDC pool on the forked network.
+  it('should successfully complete an arbitrage cycle on a forked Base mainnet', async () => {
+    // We will call the runDexCycle method, which now contains our fully integrated arbitrage engine.
     // We will capture the log output to verify the result.
 
     let logOutput = '';
@@ -35,10 +34,7 @@ describe('Havoc Integration Test', () => {
 
     console.log = originalLog; // Restore the original console.log
 
-    // Assert that the log output contains the success message and valid data
-    expect(logOutput).to.include('[AppController] Successfully fetched data for pool');
-    expect(logOutput).to.include('Liquidity:');
-    expect(logOutput).to.include('SqrtPriceX96:');
-    expect(logOutput).to.include('Tick:');
+    // Assert that the log output contains the final success message from the ArbitrageEngine
+    expect(logOutput).to.include('[ArbitrageEngine] Arbitrage cycle completed successfully.');
   }).timeout(60000); // Increase timeout to 60 seconds to allow for forking and fetching
 });


### PR DESCRIPTION
This commit performs a major integration, transplanting the core arbitrage logic from the `PROJECT-HAVOC` repository into the `gemini-citadel` framework.

This includes:
- Porting the `core`, `config`, and `utils` directories from `PROJECT-HAVOC` into a new `havoc-core` module.
- Refactoring the ported JavaScript code into modern, type-safe TypeScript, including the `UniswapV3Fetcher` and the `ArbitrageEngine`.
- Integrating the new `havoc-core` engine into the main `AppController` and `AppFactory`, replacing the old placeholder DEX logic.
- Addressing code review feedback by integrating the functional `SpatialFinder`, removing dead code, and correcting the integration test.