### PR TITLE
I have resolved the dependency conflict by removing the outdated `@no…

### DIFF
--- a/gemini-citadel/package.json
+++ b/gemini-citadel/package.json
@@ -42,7 +42,6 @@
     "viem": "^2.30.0"
   },
   "dependencies": {
-    "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "async-mutex": "^0.5.0",
     "dotenv": "^17.2.3"
   }


### PR DESCRIPTION
…micfoundation/hardhat-chai-matchers` package from the `dependencies` section of `gemini-citadel/package.json`.