### PR TITLE
fix(setup-aegis): Resolve compilation and dependency issues in setup …

### DIFF
--- a/gemini-citadel/contracts/Counter.sol
+++ b/gemini-citadel/contracts/Counter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.24;
 
 contract Counter {
   uint public x;

--- a/gemini-citadel/contracts/Counter.t.sol
+++ b/gemini-citadel/contracts/Counter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.24;
 
 import {Counter} from "./Counter.sol";
 import {Test} from "forge-std/Test.sol";

--- a/gemini-citadel/package.json
+++ b/gemini-citadel/package.json
@@ -4,6 +4,9 @@
   "main": "index.js",
   "license": "MIT",
   "type": "module",
+  "scripts": {
+    "postinstall": "node patch-forge-std.cjs"
+  },
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.6",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
@@ -17,6 +20,7 @@
     "@types/mocha": "^10.0.6",
     "@uniswap/v3-core": "^1.0.1",
     "chai": "^4.3.10",
+    "ds-test": "github:dapphub/ds-test",
     "ethers": "^6.10.0",
     "forge-std": "1.1.2",
     "hardhat": "^2.22.0",

--- a/gemini-citadel/patch-forge-std.cjs
+++ b/gemini-citadel/patch-forge-std.cjs
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join(__dirname, 'node_modules', 'forge-std', 'Test.sol');
+
+fs.readFile(filePath, 'utf8', (err, data) => {
+  if (err) {
+    // If the file doesn't exist, it's not a problem, just exit gracefully.
+    if (err.code === 'ENOENT') {
+      process.exit(0);
+    }
+    console.error('Error reading forge-std/Test.sol:', err);
+    process.exit(1);
+  }
+
+  const result = data.replace('import "ds-test/test.sol";', 'import "ds-test/src/test.sol";');
+
+  // Only write the file if it has changed.
+  if (result !== data) {
+    fs.writeFile(filePath, result, 'utf8', (err) => {
+      if (err) {
+        console.error('Error writing to forge-std/Test.sol:', err);
+        process.exit(1);
+      }
+      console.log('Successfully patched forge-std/Test.sol');
+    });
+  }
+});

--- a/gemini-citadel/yarn.lock
+++ b/gemini-citadel/yarn.lock
@@ -1596,6 +1596,10 @@ dotenv@^17.2.3:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz"
   integrity sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==
 
+"ds-test@github:dapphub/ds-test":
+  version "1.0.0"
+  resolved "https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0"
+
 dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz"


### PR DESCRIPTION
…script

The setup-aegis.sh script was failing due to a combination of a missing npm package (`ds-test`) and a Solidity compiler version mismatch.

This commit addresses these issues by:
- Adding `ds-test` as a dev dependency, installed directly from its GitHub repository.
- Introducing a `postinstall` script (`patch-forge-std.cjs`) to automatically patch the `forge-std/Test.sol` import statement to correctly locate `ds-test`.
- Updating the Solidity pragma in `Counter.sol` and `Counter.t.sol` to `^0.8.24` to align with the existing Hardhat configuration.