### PR TITLE
fix(deps): add @types/node to resolve peer dependency warnings

### DIFF
--- a/gemini-citadel/package.json
+++ b/gemini-citadel/package.json
@@ -18,6 +18,7 @@
     "@typechain/hardhat": "^9.1.0",
     "@types/chai": "^4.3.11",
     "@types/mocha": "^10.0.6",
+    "@types/node": "^20.10.0",
     "@uniswap/v3-core": "^1.0.1",
     "chai": "^4.3.10",
     "ds-test": "github:dapphub/ds-test",

--- a/gemini-citadel/test/Counter.ts
+++ b/gemini-citadel/test/Counter.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { network } from "hardhat";
+import pkg from "hardhat";
+const { network } = pkg;
 
 describe("Counter", async function () {
   const { viem } = await network.connect();

--- a/gemini-citadel/yarn.lock
+++ b/gemini-citadel/yarn.lock
@@ -860,6 +860,13 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
+"@types/node@^20.10.0":
+  version "20.19.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.23.tgz#7de99389c814071cca78656a3243f224fed7453d"
+  integrity sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==
+  dependencies:
+    undici-types "~6.21.0"
+
 "@types/node@^8.0.0":
   version "8.10.66"
   resolved "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz"
@@ -3666,6 +3673,11 @@ undici-types@~6.19.2:
   version "6.19.8"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici-types@~7.16.0:
   version "7.16.0"


### PR DESCRIPTION
Added @types/node as a dev dependency to resolve peer dependency warnings from @nomicfoundation/hardhat-toolbox and ts-node. This ensures a stable and correct installation of the project's dependencies.